### PR TITLE
Update Singularity_deepstream

### DIFF
--- a/Singularity_deepstream
+++ b/Singularity_deepstream
@@ -19,6 +19,7 @@ From: nvcr.io/nvidia/deepstream:6.1.1-devel
     cd /opt/nvidia/deepstream/deepstream/sources
     git clone https://github.com/NVIDIA-AI-IOT/deepstream_python_apps.git
     cd /opt/nvidia/deepstream/deepstream/sources/deepstream_python_apps
+    git checkout v1.1.4
     git submodule update --init
     
     # Installing Gst-python


### PR DESCRIPTION
The DeepStream version used is 6.1.1, which is compatible with the branch v1.1.4 of the DS Python binding, setting it explicitly builds the image successfully. 